### PR TITLE
To set type fix

### DIFF
--- a/src/container/to_set.cpp
+++ b/src/container/to_set.cpp
@@ -21,15 +21,16 @@
 #include <set>
 #include <unordered_set>
 
-template <typename T_container>
-[[nodiscard]] std::set<char> to_set(const T_container& container) {
-    std::set<char> set_obj(container.begin(), container.end());
-    return set_obj;
+template <typename ForwardIterator>
+[[nodiscard]] auto to_set(ForwardIterator first, ForwardIterator last)
+    -> std::set<decltype(*first)> {
+  std::set<decltype(*first)> set_obj(first, last);
+  return set_obj;
 }
 
-template <typename T_container>
-[[nodiscard]] std::unordered_set<char> to_unordered_set(
-    const T_container& container) {
-    std::unordered_set<char> set_obj(container.begin(), container.end());
-    return set_obj;
+template <typename ForwardIterator>
+[[nodiscard]] auto to_unordered_set(ForwardIterator first, ForwardIterator last)
+    -> std::unordered_set<decltype(*first)> {
+  std::unordered_set<decltype(*first)> set_obj(first, last);
+  return set_obj;
 }

--- a/src/container/to_set.cpp
+++ b/src/container/to_set.cpp
@@ -24,13 +24,13 @@
 template <typename ForwardIterator>
 [[nodiscard]] auto to_set(ForwardIterator first, ForwardIterator last)
     -> std::set<decltype(*first)> {
-  std::set<decltype(*first)> set_obj(first, last);
-  return set_obj;
+    std::set<decltype(*first)> set_obj(first, last);
+    return set_obj;
 }
 
 template <typename ForwardIterator>
 [[nodiscard]] auto to_unordered_set(ForwardIterator first, ForwardIterator last)
     -> std::unordered_set<decltype(*first)> {
-  std::unordered_set<decltype(*first)> set_obj(first, last);
-  return set_obj;
+    std::unordered_set<decltype(*first)> set_obj(first, last);
+    return set_obj;
 }

--- a/src/container/to_set.cpp
+++ b/src/container/to_set.cpp
@@ -21,16 +21,20 @@
 #include <set>
 #include <unordered_set>
 
-template <typename ForwardIterator>
-[[nodiscard]] auto to_set(ForwardIterator first, ForwardIterator last)
-    -> std::set<decltype(*first)> {
-    std::set<decltype(*first)> set_obj(first, last);
+template <typename ForwardIterator,
+          typename BaseIteratorType =
+              typename std::iterator_traits<ForwardIterator>::value_type>
+[[nodiscard]] std::set<BaseIteratorType> to_set(ForwardIterator first,
+                                                ForwardIterator last) {
+    std::set<BaseIteratorType> set_obj(first, last);
     return set_obj;
 }
 
-template <typename ForwardIterator>
-[[nodiscard]] auto to_unordered_set(ForwardIterator first, ForwardIterator last)
-    -> std::unordered_set<decltype(*first)> {
-    std::unordered_set<decltype(*first)> set_obj(first, last);
+template <typename ForwardIterator,
+          typename BaseIteratorType =
+              typename std::iterator_traits<ForwardIterator>::value_type>
+[[nodiscard]] std::unordered_set<BaseIteratorType> to_unordered_set(
+    ForwardIterator first, ForwardIterator last) {
+    std::unordered_set<BaseIteratorType> set_obj(first, last);
     return set_obj;
 }

--- a/tests/container/to_set.test.cpp
+++ b/tests/container/to_set.test.cpp
@@ -20,94 +20,37 @@
 
 #include "../../src/container/to_set.cpp"
 
-#include <algorithm>
-#include <array>
-#include <iostream>
+#include <assert.h>
+
 #include <set>
-#include <string>
 #include <unordered_set>
-
-constexpr uint16_t total_tests = 5;
-
-std::array<std::pair<std::string, std::set<char>>, total_tests> set_test_cases;
-std::array<std::pair<std::string, std::unordered_set<char>>, total_tests>
-    unordered_set_test_cases;
-
-void init_set_test_cases() {
-    set_test_cases[0].first = "";
-    set_test_cases[0].second = {};
-
-    set_test_cases[1].first = "a";
-    set_test_cases[1].second = {'a'};
-
-    set_test_cases[2].first = "aa";
-    set_test_cases[2].second = {'a'};
-
-    set_test_cases[3].first = "aba";
-    set_test_cases[3].second = {'a', 'b'};
-
-    set_test_cases[4].first = "ababa";
-    set_test_cases[4].second = {'a', 'b'};
-}
-
-void init_unordered_set_test_cases() {
-    unordered_set_test_cases[0].first = "";
-    unordered_set_test_cases[0].second = {};
-
-    unordered_set_test_cases[1].first = "a";
-    unordered_set_test_cases[1].second = {'a'};
-
-    unordered_set_test_cases[2].first = "aa";
-    unordered_set_test_cases[2].second = {'a'};
-
-    unordered_set_test_cases[3].first = "aba";
-    unordered_set_test_cases[3].second = {'a', 'b'};
-
-    unordered_set_test_cases[4].first = "ababa";
-    unordered_set_test_cases[4].second = {'a', 'b'};
-}
+#include <vector>
 
 int main() {
-    init_set_test_cases();
-    init_unordered_set_test_cases();
-    bool all_passed = true;
+    using namespace std;
+    {
+        vector<int> input = {};
+        auto output = to_set(input.begin(), input.end());
+        assert(output == set<int>());
+    }
+    {
+        vector<int> input = {1, 2, 3, 4, 5};
+        set<int> expected = {1, 2, 3, 4, 5};
+        auto output = to_set(input.begin(), input.end());
+        assert(output == expected);
+    }
+    {
+        vector<int> input = {};
+        unordered_set<int> expected = {};
+        auto output = to_unordered_set(input.begin(), input.end());
+        assert(output == expected);
+    }
+    {
+        vector<int> input = {1, 2, 3, 4, 5};
+        unordered_set<int> expected = {1, 2, 3, 4, 5};
+        auto output = to_unordered_set(input.begin(), input.end());
+        assert(output == expected);
+    }
 
-    std::cout << "Running to_set tests..." << std::endl;
-
-    std::for_each(set_test_cases.begin(), set_test_cases.end(),
-                  [&](const auto& test_case) {
-                      bool current_test_passed =
-                          to_set(test_case.first) == test_case.second;
-
-                      if (!current_test_passed) {
-                          all_passed = false;
-                          std::cout << "Failed test case: " << test_case.first
-                                    << std::endl;
-                      } else {
-                          std::cout << "Passed test case: " << test_case.first
-                                    << std::endl;
-                      }
-                  });
-
-    std::cout << "Finished to_set tests.\n";
-    std::cout << "Running to_unordered_set tests..." << std::endl;
-
-    std::for_each(unordered_set_test_cases.begin(),
-                  unordered_set_test_cases.end(), [&](const auto& test_case) {
-                      bool current_test_passed =
-                          to_unordered_set(test_case.first) == test_case.second;
-
-                      if (!current_test_passed) {
-                          all_passed = false;
-                          std::cout << "Failed test case: " << test_case.first
-                                    << std::endl;
-                      } else {
-                          std::cout << "Passed test case: " << test_case.first
-                                    << std::endl;
-                      }
-                  });
-
-    std::cout << "Finished to_unordered_set tests." << std::endl;
-
-    return !all_passed;
+    return 0;
 }


### PR DESCRIPTION
Change from container input to iterator range input. Set type is inferred from the iterator.

This same thing should be done to `run_length_encoding`.

----
**Maintainer Notes**

⚠️ *Do not delete this section. Checklist for maintainers.*

*IMPORTANT*: Complete the following checklist before merging.
- Once you are happy with the changes remove the `do not merge` for the `ready to merge` tag.
- Commits should be Squashed and Merged.
